### PR TITLE
Refactors use of substring()

### DIFF
--- a/src/main/scala/Inflector.scala
+++ b/src/main/scala/Inflector.scala
@@ -12,12 +12,17 @@ trait Inflector {
   def humanize(word: String): String = capitalize(word.replace("_", " "))
   def camelize(word: String): String = {
     val w = pascalize(word)
-    w.substring(0, 1).toLowerCase(ENGLISH) + w.substring(1)
+    w.take(1).toLowerCase(ENGLISH) + w.slice(1, w.length)
   }
   def pascalize(word: String): String = {
-    val lst = word.split("_").toList
-    (lst.headOption.map(s ⇒ s.substring(0, 1).toUpperCase(ENGLISH) + s.substring(1)).get ::
-      lst.tail.map(s ⇒ s.substring(0, 1).toUpperCase + s.substring(1))).mkString("")
+    word.split('_').toList.filterNot(_.isEmpty) match {
+      case Nil ⇒ ""
+      case h :: t ⇒ (
+          h.take(1).toUpperCase(ENGLISH) ::
+          h.slice(1, h.length) ::
+          t.map(s ⇒ s.take(1).toUpperCase + s.slice(1, s.length))
+        ).mkString("")
+    }
   }
   def underscore(word: String): String = {
     val spacesPattern = "[-\\s]".r
@@ -31,9 +36,9 @@ trait Inflector {
   }
 
   def capitalize(word: String): String =
-    word.substring(0, 1).toUpperCase(ENGLISH) + word.substring(1).toLowerCase(ENGLISH)
+    word.take(1).toUpperCase(ENGLISH) + word.slice(1, word.length).toLowerCase(ENGLISH)
   def uncapitalize(word: String): String =
-    word.substring(0, 1).toLowerCase(ENGLISH) + word.substring(1)
+    word.take(1).toLowerCase(ENGLISH) + word.slice(1, word.length)
   def ordinalize(word: String): String = ordanize(word.toInt, word)
   def ordinalize(number: Int): String = ordanize(number, number.toString)
   private def ordanize(number: Int, numberString: String) = {
@@ -90,8 +95,8 @@ trait Inflector {
   def addPlural(pattern: String, replacement: String) { plurals ::= pattern -> replacement }
   def addSingular(pattern: String, replacement: String) { singulars ::= pattern -> replacement }
   def addIrregular(singular: String, plural: String) {
-    plurals ::= (("(" + singular(0) + ")" + singular.substring(1) + "$") -> ("$1" + plural.substring(1)))
-    singulars ::= (("(" + plural(0) + ")" + plural.substring(1) + "$") -> ("$1" + singular.substring(1)))
+    plurals ::= (("(" + singular(0) + ")" + singular.slice(1, singular.length) + "$") -> ("$1" + plural.slice(1, plural.length)))
+    singulars ::= (("(" + plural(0) + ")" + plural.slice(1, plural.length) + "$") -> ("$1" + singular.slice(1, singular.length)))
   }
   def addUncountable(word: String) = uncountables ::= word
 

--- a/src/test/scala/InflectorSpec.scala
+++ b/src/test/scala/InflectorSpec.scala
@@ -21,6 +21,7 @@ class InflectorSpec extends Specification with DataTables {
 
   def dasherization = {
     "source" || "target" |
+      "" !! "" |
       "some_title" !! "some-title" |
       "some-title" !! "some-title" |
       "some_title_goes_here" !! "some-title-goes-here" |
@@ -31,6 +32,7 @@ class InflectorSpec extends Specification with DataTables {
 
   def humanization = {
     "source" || "target" |
+      "" !! "" |
       "some_title" !! "Some title" |
       "some-title" !! "Some-title" |
       "someTitle" !! "Sometitle" |
@@ -109,11 +111,15 @@ class InflectorSpec extends Specification with DataTables {
 
   def pascalization = {
     "source" || "target" |
+      "" !! "" |
+      "_" !! "" |
+      "__" !! "" |
       "customer" !! "Customer" |
       "CUSTOMER" !! "CUSTOMER" |
       "CUStomer" !! "CUStomer" |
       "customer_name" !! "CustomerName" |
       "customer_first_name" !! "CustomerFirstName" |
+      "customer__first_name" !! "CustomerFirstName" |
       "customer_first_name_goes_here" !! "CustomerFirstNameGoesHere" |
       "customer name" !! "Customer name" |> { (src, tgt) ⇒
         Inflector.pascalize(src) must_== tgt
@@ -122,11 +128,15 @@ class InflectorSpec extends Specification with DataTables {
 
   def camelization = {
     "source" || "target" |
+      "" !! "" |
+      "_" !! "" |
+      "__" !! "" |
       "customer" !! "customer" |
       "CUSTOMER" !! "cUSTOMER" |
       "CUStomer" !! "cUStomer" |
       "customer_name" !! "customerName" |
       "customer_first_name" !! "customerFirstName" |
+      "customer__first_name" !! "customerFirstName" |
       "customer_first_name_goes_here" !! "customerFirstNameGoesHere" |
       "customer name" !! "customer name" |> { (src, tgt) ⇒
         Inflector.camelize(src) must_== tgt
@@ -135,6 +145,7 @@ class InflectorSpec extends Specification with DataTables {
 
   def titleization = {
     "source" || "target" |
+      "" !! "" |
       "some title" !! "Some Title" |
       "some title" !! "Some Title" |
       "sometitle" !! "Sometitle" |
@@ -147,6 +158,7 @@ class InflectorSpec extends Specification with DataTables {
 
   def uncapitalization = {
     "source" || "target" |
+      "" !! "" |
       "some title" !! "some title" |
       "some Title" !! "some Title" |
       "SOMETITLE" !! "sOMETITLE" |
@@ -159,6 +171,7 @@ class InflectorSpec extends Specification with DataTables {
 
   def underscoring = {
     "source" || "target" |
+      "" !! "" |
       "SomeTitle" !! "some_title" |
       "some title" !! "some_title" |
       "some title that will be underscored" !! "some_title_that_will_be_underscored" |


### PR DESCRIPTION
This commit addresses https://github.com/mojolly/scala-inflector/issues/1 and a
number of other problems.

In many places the existing implementation assumes that a string will be at least one
character long by using `s.substring(0, 1)` and `s.substring(1)`. The tests missed
this because they did not include edge case, e.g. `""` or `"_"`, checks.

This commit refactors the use of `substring` to `take` and `slice`, which do not
raise exceptions. It also refactors `pascalize()` for more explicit handling of
`"__"`, which generate `""` elements in the list in the current implementation.

This is my original work, which I license to the rl project under the MIT License.